### PR TITLE
Fix the Temporary File Extension from .js to .mjs

### DIFF
--- a/src/import-config.ts
+++ b/src/import-config.ts
@@ -6,6 +6,8 @@ import { resolve } from "node:path";
 
 import { config$ } from "./config";
 
+const ext = ".mjs";
+
 export async function importConfig(
   path: string,
 ): Promise<InferOutput<typeof config$>["default"]> {
@@ -20,7 +22,7 @@ export async function importConfig(
   });
   const code = result?.code ?? "";
 
-  const tempConfigPath = resolve(tmpdir(), `acrop-${Date.now()}.js`);
+  const tempConfigPath = resolve(tmpdir(), `acrop-${Date.now()}${ext}`);
   let mod: unknown;
   try {
     writeFileSync(tempConfigPath, code);


### PR DESCRIPTION
The temporary file extension has been corrected from `.js` to `.mjs`. This change ensures that the configuration is properly loaded when executed in a CommonJS environment.

---

As an additional note, the script has been modified to add a shebang to the build output, as implemented in [this commit](https://github.com/crescware/acrop/commit/2864d286effe36ac5491d6921a505d10da7425de#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R49).