### PR TITLE
Enable CI Failure on Detected Restricted Imports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,13 @@
 import { main } from "./src";
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+main()
+  .then((succeeded) => {
+    const exitCode = succeeded ? 0 : 1;
+    console.log(`Exiting with code ${exitCode}`);
+    process.exit(exitCode);
+  })
+  .catch((e) => {
+    console.error(e);
+    console.log(`Exiting with code 1`);
+    process.exit(1);
+  });

--- a/src/log-reports/log-reports.ts
+++ b/src/log-reports/log-reports.ts
@@ -18,10 +18,11 @@ export function logReports(
     logReport(`./${relative(root, tsPath)}`, result);
   });
 
+  const unscopedFiles = relativeTsFiles.filter(
+    (v) => !scoped.has(resolve(root, v)),
+  );
+
   if (needsReportUnscoped) {
-    const unscopedFiles = relativeTsFiles.filter(
-      (v) => !scoped.has(resolve(root, v)),
-    );
     console.log(
       [underline("Unscoped Files"), gray(`(${unscopedFiles.length})`)].join(
         " ",
@@ -40,8 +41,18 @@ export function logReports(
     (
       [
         [
+          "Files Checked",
+          [
+            scoped.size,
+            scoped.size === 1 ? "file" : "files",
+            gray(`(${relativeTsFiles.length} found, ${unscopedFiles.length} unscoped)`),
+          ].join(" "),
+        ],
+        [
           "Restricted Imports",
-          `${restrictedImports} ${restrictedImports === 1 ? "line" : "lines"}`,
+          [restrictedImports, restrictedImports === 1 ? "line" : "lines"].join(
+            " ",
+          ),
         ],
         ["Duration", `${end()} ms`],
       ] as const

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { loadGitignore } from "./load-gitignore";
 import { makeAst } from "./make-ast";
 import { logReports, type Report } from "./log-reports";
 
-export async function main(): Promise<void> {
+export async function main(): Promise<boolean> {
   const args = process.argv.slice(2);
 
   const cwd = process.cwd();
@@ -133,4 +133,10 @@ export async function main(): Promise<void> {
   });
 
   logReports(root, reports, relativeTsFiles, needsReportUnscoped, scoped, end);
+
+  const restrictedImports = reports
+    .flatMap((v) => v.result)
+    .filter((v) => !v.isAllowed).length;
+
+  return restrictedImports === 0;
 }


### PR DESCRIPTION
This PR updates the process to use `process.exit()` appropriately, ensuring that the CI process will now fail with an error if one or more restricted imports are detected.






