### PR TITLE
[BREAKING CHANGE] Remove matchPattern Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "url": "git+https://github.com/crescware/acrop.git"
   },
   "scripts": {
-    "build": "npm run test -- run && tsup ./index.ts  --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && rm dist/index.js",
+    "build": "npm run check -- run && tsup ./index.ts  --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && rm dist/index.js",
+    "check": "npm run check:type && npm run test",
     "check:type": "tsc -p ./tsconfig.json --noEmit",
     "start": "tsx ./index.ts",
     "test": "vitest"

--- a/src/calc-allowed.ts
+++ b/src/calc-allowed.ts
@@ -1,0 +1,38 @@
+import { dirname, relative } from "node:path";
+
+import { importConfig } from "./import-config";
+
+type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
+
+export function calcAllowed(
+  root: string,
+  tsPath: string,
+  declaration: Declaration,
+): readonly string[] {
+  const base = ((): readonly string[] => {
+    if (
+      typeof declaration.allowed === "object" &&
+      Array.isArray(declaration.allowed)
+    ) {
+      return declaration.allowed;
+    }
+
+    if (typeof declaration.allowed === "function") {
+      return declaration.allowed(`./${relative(root, tsPath)}`) as string[];
+    }
+
+    throw new Error("invalid");
+  })();
+
+  return (
+    [
+      ...base,
+      (declaration.disallowSiblingImportsUnlessAllow ?? false)
+        ? null
+        : `./${relative(root, dirname(tsPath))}/**/*`,
+    ]
+      .filter((v) => v !== null)
+      // Add a glob pattern that allows the directory itself to include index.ts
+      .flatMap((v) => [v, v.replace(/\/\*\*\/\*$/, "")])
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,6 @@
 import {
   array,
   boolean,
-  custom,
   function_,
   minLength,
   optional,
@@ -13,21 +12,12 @@ import {
 
 const path$ = pipe(string(), minLength(1));
 const glob$ = pipe(string(), minLength(1));
-const regexp$ = custom((v) => v instanceof RegExp);
 
-const scope$ = union([
-  strictObject({
-    scope: glob$,
-    allowed: pipe(array(glob$), minLength(0)),
-    disallowSiblingImportsUnlessAllow: optional(boolean()),
-  }),
-  strictObject({
-    scope: glob$,
-    matchPattern: regexp$,
-    allowed: function_(),
-    disallowSiblingImportsUnlessAllow: optional(boolean()),
-  }),
-]);
+const scope$ = strictObject({
+  scope: glob$,
+  allowed: union([pipe(array(glob$), minLength(0)), function_()]),
+  disallowSiblingImportsUnlessAllow: optional(boolean()),
+});
 
 export const config$ = strictObject({
   default: strictObject({

--- a/src/find-import-paths.ts
+++ b/src/find-import-paths.ts
@@ -1,8 +1,11 @@
-import { InferOutput } from "valibot";
+import { InferOutput, NonNullable } from "valibot";
 
 import { makeAst } from "./make-ast";
 import { isImportDeclaration, node$ } from "./ast";
 import { calcLineNumber } from "./calc-line-number";
+
+type Ast = NonNullable<ReturnType<typeof makeAst>>["ast"];
+type Positions = NonNullable<ReturnType<typeof makeAst>>["positions"];
 
 type ImportInfo = Readonly<{
   path: string;
@@ -11,17 +14,17 @@ type ImportInfo = Readonly<{
 }>;
 
 export function findImportPaths(
-  ast: ReturnType<typeof makeAst>["ast"],
-  positions_: ReturnType<typeof makeAst>["positions"],
+  ast: Ast,
+  positions_: Positions,
 ): readonly ImportInfo[] {
   const importInfos: ImportInfo[] = [];
 
   function traverse(
     node: InferOutput<typeof node$>,
-    positions: ReturnType<typeof makeAst>["positions"],
+    positions: Positions,
   ): void {
     if (isImportDeclaration(node)) {
-      const { line, column } = calcLineNumber(positions, node.start + 1);
+      const { line, column } = calcLineNumber(positions, node.source.start + 1);
       importInfos.push({
         path: node.source.value,
         line,

--- a/src/log-reports/index.ts
+++ b/src/log-reports/index.ts
@@ -1,2 +1,3 @@
+export { logErrors, type ErrorReport } from "./log-errors";
 export { logReports } from "./log-reports";
 export { type Report } from "./report";

--- a/src/log-reports/log-errors.ts
+++ b/src/log-reports/log-errors.ts
@@ -1,0 +1,14 @@
+import { red } from "yoctocolors";
+
+export type ErrorReport = Readonly<{
+  path: string;
+  errors: readonly string[];
+}>;
+
+export function logErrors(errorsRef: readonly ErrorReport[]): void {
+  errorsRef.forEach((v) => {
+    console.log(red(v.path));
+    console.log("");
+    v.errors.forEach((line) => console.log(line));
+  });
+}

--- a/src/log-reports/log-reports.ts
+++ b/src/log-reports/log-reports.ts
@@ -1,6 +1,6 @@
 import timeSpan from "time-span";
 import { relative, resolve } from "node:path";
-import { gray, underline, yellow } from "yoctocolors";
+import { gray, green, underline, yellow } from "yoctocolors";
 import { getBorderCharacters, table } from "table";
 
 import { logReport } from "./log-report";
@@ -45,7 +45,9 @@ export function logReports(
           [
             scoped.size,
             scoped.size === 1 ? "file" : "files",
-            gray(`(${relativeTsFiles.length} found, ${unscopedFiles.length} unscoped)`),
+            gray(
+              `(${relativeTsFiles.length} found, ${unscopedFiles.length} unscoped)`,
+            ),
           ].join(" "),
         ],
         [
@@ -56,7 +58,10 @@ export function logReports(
         ],
         ["Duration", `${end()} ms`],
       ] as const
-    ).map(([header, value]) => [gray(header), yellow(value)]),
+    ).map(([header, value]) => [
+      gray(header),
+      restrictedImports === 0 ? green(value) : yellow(value),
+    ]),
     {
       border: getBorderCharacters("void"),
       columnDefault: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,12 +94,10 @@ export async function main(): Promise<boolean> {
           (declaration as any).matchPattern !== undefined &&
           (declaration as any).matchPattern !== null
         ) {
-          const pattern = (declaration as any)
-            .matchPattern as unknown as RegExp;
-          const matched = `./${relative(root, dirname(tsPath))}`.match(pattern);
-
           const allowed = [
-            ...(declaration.allowed(matched) as string[]),
+            ...(declaration.allowed(
+              `./${relative(root, dirname(tsPath))}`,
+            ) as string[]),
             (declaration.disallowSiblingImportsUnlessAllow ?? false)
               ? null
               : `./${relative(root, dirname(tsPath))}/**/*`,

--- a/src/make-ast.ts
+++ b/src/make-ast.ts
@@ -1,5 +1,6 @@
-import { parseSync } from "oxc-parser";
 import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { parseSync } from "oxc-parser";
 import { InferOutput, parse } from "valibot";
 
 import { ast$ } from "./ast";
@@ -8,13 +9,22 @@ import { getLineStartPositions } from "./get-line-start-positions";
 type Return = Readonly<{
   ast: InferOutput<typeof ast$>;
   positions: ReturnType<typeof getLineStartPositions>;
-}>;
+}> | null;
 
-export function makeAst(path: string): Return {
+export function makeAst(path: string, errorsRef: unknown[]): Return {
   const code = readFileSync(path, "utf-8");
-  const result = parseSync(code, { sourceType: "module" });
-  const ast = JSON.parse(result.program);
 
+  const result = parseSync(code, {
+    sourceType: "module",
+    sourceFilename: basename(path),
+  });
+
+  if (0 < result.errors.length) {
+    errorsRef.push({ path, errors: result.errors });
+    return null;
+  }
+
+  const ast = JSON.parse(result.program);
   const positions = getLineStartPositions(code);
 
   return { ast: parse(ast$, ast), positions };


### PR DESCRIPTION
This PR discontinues the `matchPattern` option, as testing revealed that providing the raw path allows for greater flexibility in configuration. Additionally, several bugs related to the switch to oxc have been fixed, and error handling has been enhanced.