### PR TITLE
Introduce VerboseLogger to Display Performance Metrics

### DIFF
--- a/src/find-import-paths.ts
+++ b/src/find-import-paths.ts
@@ -8,7 +8,9 @@ type Ast = NonNullable<ReturnType<typeof makeAst>>["ast"];
 type Positions = NonNullable<ReturnType<typeof makeAst>>["positions"];
 
 type ImportInfo = Readonly<{
-  path: string;
+  path: Readonly<{
+    relative: string;
+  }>;
   line: number;
   column: number;
 }>;
@@ -26,7 +28,7 @@ export function findImportPaths(
     if (isImportDeclaration(node)) {
       const { line, column } = calcLineNumber(positions, node.source.start + 1);
       importInfos.push({
-        path: node.source.value,
+        path: { relative: node.source.value },
         line,
         column,
       });

--- a/src/log-tree/build-node-from-results.ts
+++ b/src/log-tree/build-node-from-results.ts
@@ -4,8 +4,6 @@ import { TableNode } from "./log-tree";
 export function buildNodeFromResults(
   filtered: readonly Result[],
 ): TableNode | null {
-
-
   if (filtered.length === 0) {
     return null;
   }
@@ -23,7 +21,7 @@ export function buildNodeFromResults(
             },
           ],
         },
-        { type: "text", elements: [{ text: v.path }] },
+        { type: "text", elements: [{ text: v.path.relative }] },
       ];
     }),
     alignment: ["left", "left"],

--- a/src/log-tree/build-nodes.ts
+++ b/src/log-tree/build-nodes.ts
@@ -1,5 +1,3 @@
-import { resolve } from "node:path";
-
 import { buildNodesFromErrors } from "./build-nodes-from-errors";
 import { buildReportNodes } from "./build-report-nodes";
 import { buildSummaryReportNode } from "./build-summary-report-node";
@@ -9,8 +7,7 @@ import { LogNode } from "./log-tree";
 export function buildNodes(
   errorsRef: Parameters<typeof buildNodesFromErrors>[0],
   reports: Parameters<typeof buildReportNodes>[0],
-  root: string,
-  relativeTsFiles: Parameters<typeof buildSummaryReportNode>[0],
+  tsFiles: Parameters<typeof buildSummaryReportNode>[0],
   scoped: Parameters<typeof buildSummaryReportNode>[1],
   needsReportUnscoped: Parameters<typeof buildUnscopedReportNode>[0],
   duration: Parameters<typeof buildSummaryReportNode>[2],
@@ -19,9 +16,7 @@ export function buildNodes(
   const errorsNodes = buildNodesFromErrors(errorsRef);
   const reportNodes = buildReportNodes(reports);
 
-  const unscopedFiles = relativeTsFiles.filter(
-    (v) => !scoped.has(resolve(root, v)),
-  );
+  const unscopedFiles = tsFiles.filter((v) => !scoped.has(v.absolute));
 
   const unscopedFilesCount = unscopedFiles.length;
 
@@ -32,7 +27,7 @@ export function buildNodes(
   );
 
   const summaryReportNode = buildSummaryReportNode(
-    relativeTsFiles,
+    tsFiles,
     scoped,
     duration,
     restrictedImports,

--- a/src/log-tree/build-report-nodes.ts
+++ b/src/log-tree/build-report-nodes.ts
@@ -5,15 +5,14 @@ import { type Report } from "./report";
 export function buildReportNodes(
   reports: readonly Report[],
 ): readonly LogNode[] {
-  return reports.flatMap(({ tsPath, result }): readonly LogNode[] => {
-    const targetPath = `./${tsPath.relative}`;
+  return reports.flatMap(({ path, result }): readonly LogNode[] => {
     const restricted = result.filter((v) => !v.isAllowed);
 
     const textNode = {
       type: "text",
       elements: [
         {
-          text: targetPath,
+          text: path.relative,
           attributes: [
             { type: "modifier", value: "underline" },
             { type: "color", value: "gray" },

--- a/src/log-tree/build-summary-report-node.ts
+++ b/src/log-tree/build-summary-report-node.ts
@@ -1,7 +1,12 @@
 import { TableNode } from "./log-tree";
 
+type TsFiles = readonly Readonly<{
+  relative: string;
+  absolute: string;
+}>[];
+
 export function buildSummaryReportNode(
-  relativeTsFiles: readonly string[],
+  tsFiles: TsFiles,
   scoped: Set<string>,
   duration: number,
   restrictedImports: number,
@@ -34,7 +39,7 @@ export function buildSummaryReportNode(
             },
             { text: " " },
             {
-              text: `(${relativeTsFiles.length} found, ${unscopedFilesCount} unscoped)`,
+              text: `(${tsFiles.length} found, ${unscopedFilesCount} unscoped)`,
               attributes: [{ type: "color", value: "gray" }],
             },
           ],

--- a/src/log-tree/build-tree.ts
+++ b/src/log-tree/build-tree.ts
@@ -4,19 +4,17 @@ import { buildNodes } from "./build-nodes";
 export function buildTree(
   errorsRef: Parameters<typeof buildNodes>[0],
   reports: Parameters<typeof buildNodes>[1],
-  root: Parameters<typeof buildNodes>[2],
-  relativeTsFiles: Parameters<typeof buildNodes>[3],
-  scoped: Parameters<typeof buildNodes>[4],
-  needsReportUnscoped: Parameters<typeof buildNodes>[5],
-  duration: Parameters<typeof buildNodes>[6],
-  restrictedImports: Parameters<typeof buildNodes>[7],
+  tsFiles: Parameters<typeof buildNodes>[2],
+  scoped: Parameters<typeof buildNodes>[3],
+  needsReportUnscoped: Parameters<typeof buildNodes>[4],
+  duration: Parameters<typeof buildNodes>[5],
+  restrictedImports: Parameters<typeof buildNodes>[6],
 ): LogTree {
   return {
     nodes: buildNodes(
       errorsRef,
       reports,
-      root,
-      relativeTsFiles,
+      tsFiles,
       scoped,
       needsReportUnscoped,
       duration,

--- a/src/log-tree/build-unscoped-report-node.ts
+++ b/src/log-tree/build-unscoped-report-node.ts
@@ -1,9 +1,14 @@
 import { TextNode } from "./log-tree";
 
+type UnscopedFiles = readonly Readonly<{
+  relative: string;
+  absolute: string;
+}>[];
+
 export function buildUnscopedReportNode(
   needsReportUnscoped: boolean,
   unscopedFilesCount: number,
-  unscopedFiles: readonly string[],
+  unscopedFiles: UnscopedFiles,
 ): readonly TextNode[] {
   return needsReportUnscoped
     ? ([
@@ -25,7 +30,7 @@ export function buildUnscopedReportNode(
         ...unscopedFiles.map((v): TextNode => {
           return {
             type: "text",
-            elements: [{ text: v }],
+            elements: [{ text: v.relative }],
           };
         }),
         { type: "text", elements: [{ text: " " }] },

--- a/src/log-tree/report.ts
+++ b/src/log-tree/report.ts
@@ -1,9 +1,9 @@
 import { buildNodeFromResults } from "./build-node-from-results";
 
 export type Report = Readonly<{
-  tsPath: {
+  path: Readonly<{
     relative: string;
     absolute: string;
-  };
+  }>;
   result: Parameters<typeof buildNodeFromResults>[0];
 }>;

--- a/src/log-tree/result.ts
+++ b/src/log-tree/result.ts
@@ -1,5 +1,7 @@
 export type Result = Readonly<{
-  path: string;
+  path: Readonly<{
+    relative: string;
+  }>;
   line: number;
   column: number;
   isAllowed: boolean;

--- a/src/verbose-logger.ts
+++ b/src/verbose-logger.ts
@@ -1,0 +1,37 @@
+import timeSpan from "time-span";
+
+type StartImplReturn = () => void;
+
+export class VerboseLogger {
+  #verbose: boolean = false;
+
+  constructor(verbose: boolean) {
+    this.#verbose = verbose;
+  }
+
+  start(v: string): StartImplReturn {
+    return this.#startImpl(v, false);
+  }
+
+  startWithHeader(v: string): StartImplReturn {
+    return this.#startImpl(v, true);
+  }
+
+  #startImpl(v: string, showStartLog: boolean): StartImplReturn {
+    if (!this.#verbose) {
+      return () => {
+        // noop
+      };
+    }
+
+    if (showStartLog) {
+      console.log(v);
+    }
+
+    const end = timeSpan();
+
+    return () => {
+      console.log([`${v}:`, end(), "ms"].join(" "));
+    };
+  }
+}


### PR DESCRIPTION
This PR introduces a `VerboseLogger`, allowing the performance of each process to be displayed when using the `--verbose` option.