### PR TITLE
Migrate dependency configuration from `allowed` to `rules[0].allowed` structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 	"scripts": {
 		"build": "npm run check -- run && tsup ./index.ts  --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && rm dist/index.js",
 		"check": "npm run check:types && npm run check:lint && npm run test",
-
 		"check:lint": "biome lint",
 		"check:types": "tsc -p ./tsconfig.json --noEmit",
 		"start": "tsx ./index.ts",

--- a/src/calc-allowed.ts
+++ b/src/calc-allowed.ts
@@ -8,21 +8,18 @@ type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
 export function calcAllowed(
 	root: string,
 	tsPath: string,
-	declaration_: Declaration,
+	declaration: Declaration,
 ): readonly string[] {
 	const base = ((): readonly string[] => {
-		const declaration = declaration_.rules[0] ?? null;
-		assertExists(declaration);
+		const rule = declaration.rules[0] ?? null;
+		assertExists(rule);
 
-		if (
-			typeof declaration.allowed === "object" &&
-			Array.isArray(declaration.allowed)
-		) {
-			return declaration.allowed;
+		if (typeof rule.allowed === "object" && Array.isArray(rule.allowed)) {
+			return rule.allowed;
 		}
 
-		if (typeof declaration.allowed === "function") {
-			return declaration.allowed(`./${relative(root, tsPath)}`) as string[];
+		if (typeof rule.allowed === "function") {
+			return rule.allowed(`./${relative(root, tsPath)}`) as string[];
 		}
 
 		throw new Error(
@@ -33,7 +30,7 @@ export function calcAllowed(
 	return (
 		[
 			...base,
-			(declaration_.disallowSiblingImportsUnlessAllow ?? false)
+			(declaration.disallowSiblingImportsUnlessAllow ?? false)
 				? null
 				: `./${relative(root, dirname(tsPath))}/**/*`,
 		]

--- a/src/calc-allowed.ts
+++ b/src/calc-allowed.ts
@@ -1,5 +1,6 @@
 import { dirname, relative } from "node:path";
 
+import { assertExists } from "./exists/assert-exists";
 import type { importConfig } from "./import-config";
 
 type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
@@ -7,9 +8,12 @@ type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
 export function calcAllowed(
 	root: string,
 	tsPath: string,
-	declaration: Declaration,
+	declaration_: Declaration,
 ): readonly string[] {
 	const base = ((): readonly string[] => {
+		const declaration = declaration_.rules[0] ?? null;
+		assertExists(declaration);
+
 		if (
 			typeof declaration.allowed === "object" &&
 			Array.isArray(declaration.allowed)
@@ -21,13 +25,15 @@ export function calcAllowed(
 			return declaration.allowed(`./${relative(root, tsPath)}`) as string[];
 		}
 
-		throw new Error("invalid");
+		throw new Error(
+			"Invalid configuration: rules[0].allowed is not properly defined",
+		);
 	})();
 
 	return (
 		[
 			...base,
-			(declaration.disallowSiblingImportsUnlessAllow ?? false)
+			(declaration_.disallowSiblingImportsUnlessAllow ?? false)
 				? null
 				: `./${relative(root, dirname(tsPath))}/**/*`,
 		]

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,9 +13,13 @@ import {
 const path$ = pipe(string(), minLength(1));
 const glob$ = pipe(string(), minLength(1));
 
+const rule$ = strictObject({
+	allowed: union([pipe(array(glob$), minLength(0)), function_()]),
+});
+
 const scope$ = strictObject({
 	scope: glob$,
-	allowed: union([pipe(array(glob$), minLength(0)), function_()]),
+	rules: array(rule$),
 	disallowSiblingImportsUnlessAllow: optional(boolean()),
 });
 

--- a/src/exists/assert-exists.ts
+++ b/src/exists/assert-exists.ts
@@ -1,0 +1,10 @@
+import { exists } from "./exists";
+
+export function assertExists<T>(
+	v: T | null | undefined,
+	target = "",
+): asserts v is NonNullable<T> {
+	if (!exists(v)) {
+		throw new Error(`${target} should be specified`.trim());
+	}
+}

--- a/src/exists/exists.ts
+++ b/src/exists/exists.ts
@@ -1,0 +1,3 @@
+export function exists<T>(v: T | null | undefined): v is T {
+	return typeof v !== "undefined" && v !== null;
+}

--- a/src/testing/case-01/acrop.config.ts
+++ b/src/testing/case-01/acrop.config.ts
@@ -3,7 +3,7 @@ const config = {
 	scopes: [
 		{
 			scope: "./a/**/*",
-			allowed: ["./b/**/*"],
+			rules: [{ allowed: ["./b/**/*"] }],
 		},
 	],
 };

--- a/src/testing/case-01/case-01.test.ts
+++ b/src/testing/case-01/case-01.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { timeEndMock } from "../../owned-time-span.mock";
 import * as logReportsMod from "../../log-reports";
+import { timeEndMock } from "../../owned-time-span.mock";
 
 const outputFromTreeSpy = vi.spyOn(logReportsMod, "outputFromTree");
 
@@ -45,7 +45,7 @@ describe("Case 01", () => {
 			});
 
 			test(`should allow "./b" in the scope`, () => {
-				expect(config.scopes[0]?.allowed).toEqual(["./b/**/*"]);
+				expect(config.scopes[0]?.rules[0]?.allowed).toEqual(["./b/**/*"]);
 			});
 		});
 

--- a/src/testing/case-02/acrop.config.ts
+++ b/src/testing/case-02/acrop.config.ts
@@ -3,7 +3,7 @@ const config = {
 	scopes: [
 		{
 			scope: "./a/**/*",
-			allowed: [],
+			rules: [{ allowed: [] }],
 		},
 	],
 };

--- a/src/testing/case-02/case-02.test.ts
+++ b/src/testing/case-02/case-02.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { timeEndMock } from "../../owned-time-span.mock";
 import * as logReportsMod from "../../log-reports";
+import { timeEndMock } from "../../owned-time-span.mock";
 
 const outputFromTreeSpy = vi.spyOn(logReportsMod, "outputFromTree");
 
@@ -45,7 +45,7 @@ describe("Case 02", () => {
 			});
 
 			test("should disallow in the scope", () => {
-				expect(config.scopes[0]?.allowed).toEqual([]);
+				expect(config.scopes[0]?.rules[0]?.allowed).toEqual([]);
 			});
 		});
 

--- a/src/testing/case-03/acrop.config.ts
+++ b/src/testing/case-03/acrop.config.ts
@@ -3,7 +3,7 @@ const config = {
 	scopes: [
 		{
 			scope: "./a/**/*",
-			allowed: [],
+			rules: [{ allowed: [] }],
 			disallowSiblingImportsUnlessAllow: true,
 		},
 	],

--- a/src/testing/case-03/case-03.test.ts
+++ b/src/testing/case-03/case-03.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import * as logReportsMod from "../../log-reports";
 import { timeEndMock } from "../../owned-time-span.mock";
@@ -45,7 +45,7 @@ describe("Case 03", () => {
 			});
 
 			test("should disallow in the scope", () => {
-				expect(config.scopes[0]?.allowed).toEqual([]);
+				expect(config.scopes[0]?.rules[0]?.allowed).toEqual([]);
 			});
 
 			test("should disallow in the scope", () => {

--- a/src/testing/case-04/acrop.config.ts
+++ b/src/testing/case-04/acrop.config.ts
@@ -3,7 +3,7 @@ const config = {
 	scopes: [
 		{
 			scope: "./a/**/*",
-			allowed: ["./a/a3"],
+			rules: [{ allowed: ["./a/a3"] }],
 			disallowSiblingImportsUnlessAllow: true,
 		},
 	],

--- a/src/testing/case-04/case-04.test.ts
+++ b/src/testing/case-04/case-04.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import * as logReportsMod from "../../log-reports";
 import { timeEndMock } from "../../owned-time-span.mock";
@@ -45,7 +45,7 @@ describe("Case 04", () => {
 			});
 
 			test("should disallow in the scope", () => {
-				expect(config.scopes[0]?.allowed).toEqual(["./a/a3"]);
+				expect(config.scopes[0]?.rules[0]?.allowed).toEqual(["./a/a3"]);
 			});
 
 			test("should disallow in the scope", () => {


### PR DESCRIPTION
This PR implements the first step of our dependency linter configuration redesign by migrating from the previous flat structure to a rules-based approach. The main changes include:

1. Updated the configuration schema to support a `rules` array containing rule objects with `allowed` properties
2. Modified the `calcAllowed` function to extract allowed paths from `rules[0].allowed` instead of directly from `allowed`
3. Added utility functions `exists` and `assertExists` for null checking with proper TypeScript type assertions
4. Updated all test cases to use the new configuration format
5. Maintained backward compatibility with the `disallowSiblingImportsUnlessAllow` flag (to be replaced in future PRs)

This change provides a foundation for the upcoming enhancements including support for `restricted`, `warn`, and `deprecated` rules, while preserving existing functionality.