### PR TITLE
Add sibling imports rule support and improve build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"url": "git+https://github.com/crescware/acrop.git"
 	},
 	"scripts": {
-		"build": "npm run check -- run && tsup ./index.ts  --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && rm dist/index.js",
+		"build": "npm run check -- run && tsup ./index.ts --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && chmod +x dist/index.mjs && rm dist/index.js",
 		"check": "npm run check:types && npm run check:lint && npm run test",
 		"check:lint": "biome lint",
 		"check:types": "tsc -p ./tsconfig.json --noEmit",

--- a/src/check/calc-rules.ts
+++ b/src/check/calc-rules.ts
@@ -1,4 +1,5 @@
-import { relative } from "node:path";
+import { dirname, relative } from "node:path";
+import { exists } from "../exists/exists";
 import type { importConfig } from "../import-config";
 
 type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
@@ -7,6 +8,24 @@ export type Rule = Readonly<{
 	type: "allowed" | "restricted";
 	pattern: string;
 }>;
+
+function processSiblingRule(
+	rule: NonNullable<Declaration["rules"][number]>,
+	root: string,
+	tsPath: string,
+): Readonly<{
+	type: "allowed" | "restricted";
+	pattern: string;
+}> | null {
+	if (!("sibling" in rule)) {
+		return null;
+	}
+
+	return {
+		type: rule.sibling ? "allowed" : "restricted",
+		pattern: `./${relative(root, dirname(tsPath))}/**/*`,
+	};
+}
 
 function processAllowedRule(
 	rule: NonNullable<Declaration["rules"][number]>,
@@ -60,6 +79,12 @@ export function calcRules(
 	const orderedRules: /* readwrite */ Rule[] = [];
 
 	for (const rule of declaration.rules) {
+		const siblingRule = processSiblingRule(rule, root, tsPath);
+		if (exists(siblingRule)) {
+			orderedRules.push(siblingRule);
+			continue;
+		}
+
 		const allowedPaths = processAllowedRule(rule, relativePath);
 		for (const pattern of allowedPaths) {
 			orderedRules.push({ type: "allowed", pattern });

--- a/src/check/calc-rules.ts
+++ b/src/check/calc-rules.ts
@@ -8,6 +8,16 @@ export type Rule = Readonly<{
 	pattern: string;
 }>;
 
+function expandPatterns(patterns: readonly string[]): readonly string[] {
+	return patterns.flatMap((pattern) => {
+		if (pattern.endsWith("/**/*")) {
+			return [pattern, pattern.replace(/\/\*\*\/\*$/, "")];
+		}
+
+		return [pattern, `${pattern}/**/*`];
+	});
+}
+
 function processSiblingRule(
 	rule: NonNullable<Declaration["rules"][number]>,
 	tsPath: string,
@@ -40,17 +50,19 @@ function processAllowedRule(
 		return [];
 	}
 
-	if (typeof rule.allowed === "object" && Array.isArray(rule.allowed)) {
-		return rule.allowed;
-	}
+	const paths: readonly string[] = (() => {
+		if (typeof rule.allowed === "object" && Array.isArray(rule.allowed)) {
+			return rule.allowed;
+		}
+		if (typeof rule.allowed === "function") {
+			return rule.allowed(relativePath) as string[];
+		}
+		throw new Error(
+			"Invalid configuration: rule.allowed is not properly defined",
+		);
+	})();
 
-	if (typeof rule.allowed === "function") {
-		return rule.allowed(relativePath) as string[];
-	}
-
-	throw new Error(
-		"Invalid configuration: rule.allowed is not properly defined",
-	);
+	return expandPatterns(paths);
 }
 
 function processRestrictedRule(
@@ -61,17 +73,19 @@ function processRestrictedRule(
 		return [];
 	}
 
-	if (typeof rule.restricted === "object" && Array.isArray(rule.restricted)) {
-		return rule.restricted;
-	}
+	const paths: readonly string[] = (() => {
+		if (typeof rule.restricted === "object" && Array.isArray(rule.restricted)) {
+			return rule.restricted;
+		}
+		if (typeof rule.restricted === "function") {
+			return rule.restricted(relativePath) as string[];
+		}
+		throw new Error(
+			"Invalid configuration: rule.restricted is not properly defined",
+		);
+	})();
 
-	if (typeof rule.restricted === "function") {
-		return rule.restricted(relativePath) as string[];
-	}
-
-	throw new Error(
-		"Invalid configuration: rule.restricted is not properly defined",
-	);
+	return expandPatterns(paths);
 }
 
 export function calcRules(

--- a/src/check/calc-rules.ts
+++ b/src/check/calc-rules.ts
@@ -1,5 +1,4 @@
 import { dirname, relative } from "node:path";
-import { exists } from "../exists/exists";
 import type { importConfig } from "../import-config";
 
 type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
@@ -11,20 +10,26 @@ export type Rule = Readonly<{
 
 function processSiblingRule(
 	rule: NonNullable<Declaration["rules"][number]>,
-	root: string,
 	tsPath: string,
-): Readonly<{
-	type: "allowed" | "restricted";
-	pattern: string;
-}> | null {
+	root: string,
+):
+	| readonly Readonly<{
+			type: "allowed" | "restricted";
+			pattern: string;
+	  }>[]
+	| null {
 	if (!("sibling" in rule)) {
 		return null;
 	}
 
-	return {
-		type: rule.sibling ? "allowed" : "restricted",
-		pattern: `./${relative(root, dirname(tsPath))}/**/*`,
-	};
+	const basePath = `./${relative(root, dirname(tsPath))}`;
+	const patterns = [`${basePath}/**/*`, basePath];
+
+	const ruleType = rule.sibling ? "allowed" : "restricted";
+
+	return patterns.map((pattern) => {
+		return { type: ruleType, pattern };
+	});
 }
 
 function processAllowedRule(
@@ -79,9 +84,9 @@ export function calcRules(
 	const orderedRules: /* readwrite */ Rule[] = [];
 
 	for (const rule of declaration.rules) {
-		const siblingRule = processSiblingRule(rule, root, tsPath);
-		if (exists(siblingRule)) {
-			orderedRules.push(siblingRule);
+		const siblingRules = processSiblingRule(rule, tsPath, root);
+		if (siblingRules !== null) {
+			orderedRules.push(...siblingRules);
 			continue;
 		}
 

--- a/src/import-config/config.ts
+++ b/src/import-config/config.ts
@@ -1,5 +1,6 @@
 import {
 	array,
+	boolean,
 	function_,
 	minLength,
 	pipe,
@@ -17,6 +18,9 @@ const rule$ = union([
 	}),
 	strictObject({
 		restricted: union([pipe(array(glob$), minLength(0)), function_()]),
+	}),
+	strictObject({
+		sibling: boolean(),
 	}),
 ]);
 


### PR DESCRIPTION
- Improved build process
  - Added executable permission to output file by adding `chmod +x` command to the build script
- Added sibling rule support
  - Implemented functionality to allow or restrict imports from sibling directories
- Fixed sibling rule implementation: 
  - Corrected parameter order in the `processSiblingRule()` function
  - Modified return type to handle multiple patterns
  - Removed dependency on unused `exists()` function
- Enhanced pattern handling:
  - Added `expandPatterns()` function to generate both directory and wildcard patterns
  - Applied pattern expansion to allowed and restricted rules
  - Improved code structure with cleaner functional patterns
