### PR TITLE
Add support for `only: true` flag in config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"url": "git+https://github.com/crescware/acrop.git"
 	},
 	"scripts": {
-		"build": "npm run check -- run && tsup ./index.ts --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && chmod +x dist/index.mjs && rm dist/index.js",
+		"build": "npm run check && tsup ./index.ts --format esm && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.mjs && chmod +x dist/index.mjs && rm dist/index.js",
 		"check": "npm run check:types && npm run check:lint && npm run test",
 		"check:lint": "biome lint",
 		"check:types": "tsc -p ./tsconfig.json --noEmit",

--- a/src/check/check-scope.ts
+++ b/src/check/check-scope.ts
@@ -1,0 +1,52 @@
+import { dirname, relative, resolve } from "node:path";
+
+import { exists } from "../exists";
+import type { Report } from "../log-tree";
+import type { VerboseLogger } from "../verbose-logger";
+import { analyzeImportAccess } from "./analyze-import-access";
+import { calcRules } from "./calc-rules";
+import type { ErrorReport } from "./error-report";
+import { findImportPaths } from "./find-import-paths";
+import { makeAst } from "./make-ast";
+
+export function checkScope(
+	logger: VerboseLogger,
+	declaration: Parameters<typeof calcRules>[2],
+	filtered: readonly { relative: string; absolute: string }[],
+	root: string,
+	scoped: Set<string>,
+	errorsRef: /* readwrite */ ErrorReport[],
+	reports: /* readwrite */ Report[],
+): void {
+	for (const path of filtered) {
+		const end3 = logger.start(`> > "${path.relative}" Make ast`);
+
+		const makeAstResult = makeAst(path.absolute, errorsRef);
+		if (!exists(makeAstResult)) {
+			end3();
+			continue;
+		}
+		end3();
+
+		const { ast, positions } = makeAstResult;
+		const rules = calcRules(root, path.absolute, declaration);
+
+		const end4 = logger.start(`> > "${path.relative}" Find import paths`);
+		const infoArray = findImportPaths(ast, positions).map(
+			(v): ReturnType<typeof findImportPaths>[number] => {
+				const relativePath = `./${relative(root, resolve(dirname(path.absolute), v.path.relative))}`;
+				return {
+					path: { relative: relativePath },
+					line: v.line,
+					column: v.column,
+				};
+			},
+		);
+		end4();
+
+		const analyzed = analyzeImportAccess(logger, rules, infoArray);
+
+		reports.push({ path, result: analyzed });
+		scoped.add(path.absolute);
+	}
+}

--- a/src/check/check.ts
+++ b/src/check/check.ts
@@ -37,6 +37,7 @@ export function check(
 		console.info(
 			`Found ${onlyScopes.length} scope(s) with "only: true", processing only these scopes`,
 		);
+		console.info(""); // blank
 	}
 
 	for (const declaration of scopeDeclarations) {

--- a/src/check/check.ts
+++ b/src/check/check.ts
@@ -14,6 +14,7 @@ type Return = Readonly<{
 	scoped: Set<string>;
 	errorsRef: readonly ErrorReport[];
 	reports: readonly Report[];
+	hasOnlyScopes: boolean;
 }>;
 
 export function check(
@@ -28,7 +29,17 @@ export function check(
 	const errorsRef = [] as ErrorReport[];
 	const reports = [] as Report[];
 
-	for (const declaration of config.scopes) {
+	const onlyScopes = config.scopes.filter((scope) => scope.only);
+	const hasOnlyScopes = 0 < onlyScopes.length;
+	const scopeDeclarations = hasOnlyScopes ? onlyScopes : config.scopes;
+
+	if (hasOnlyScopes) {
+		console.info(
+			`Found ${onlyScopes.length} scope(s) with "only: true", processing only these scopes`,
+		);
+	}
+
+	for (const declaration of scopeDeclarations) {
 		const end2 = logger.start(`> "${declaration.scope}" Matched file in scope`);
 
 		const filtered = tsFiles.filter((tsFile) => {
@@ -79,5 +90,10 @@ export function check(
 
 	end1();
 
-	return { scoped, errorsRef, reports };
+	return {
+		scoped,
+		errorsRef,
+		reports,
+		hasOnlyScopes,
+	};
 }

--- a/src/check/check.ts
+++ b/src/check/check.ts
@@ -1,25 +1,20 @@
-import { dirname, relative, resolve } from "node:path";
 import { minimatch } from "minimatch";
 
 import type { importConfig } from "../import-config";
 import type { Report } from "../log-tree";
 import type { VerboseLogger } from "../verbose-logger";
-import { analyzeImportAccess } from "./analyze-import-access";
-import { calcRules } from "./calc-rules";
+import { checkScope } from "./check-scope";
 import type { ErrorReport } from "./error-report";
-import { findImportPaths } from "./find-import-paths";
-import { makeAst } from "./make-ast";
 
 type Return = Readonly<{
 	scoped: Set<string>;
 	errorsRef: readonly ErrorReport[];
 	reports: readonly Report[];
-	hasOnlyScopes: boolean;
 }>;
 
 export function check(
 	logger: VerboseLogger,
-	config: Awaited<ReturnType<typeof importConfig>>,
+	scopes: Awaited<ReturnType<typeof importConfig>>["scopes"],
 	tsFiles: readonly { relative: string; absolute: string }[],
 	root: string,
 ): Return {
@@ -29,20 +24,8 @@ export function check(
 	const errorsRef = [] as ErrorReport[];
 	const reports = [] as Report[];
 
-	const onlyScopes = config.scopes.filter((scope) => scope.only);
-	const hasOnlyScopes = 0 < onlyScopes.length;
-	const scopeDeclarations = hasOnlyScopes ? onlyScopes : config.scopes;
-
-	if (hasOnlyScopes) {
-		console.info(
-			`Found ${onlyScopes.length} scope(s) with "only: true", processing only these scopes`,
-		);
-		console.info(""); // blank
-	}
-
-	for (const declaration of scopeDeclarations) {
+	for (const declaration of scopes) {
 		const end2 = logger.start(`> "${declaration.scope}" Matched file in scope`);
-
 		const filtered = tsFiles.filter((tsFile) => {
 			const end3 = logger.start(`> > "${tsFile.relative}" Match file`);
 			if (scoped.has(tsFile.absolute)) {
@@ -53,48 +36,12 @@ export function check(
 			end3();
 			return ret;
 		});
-
 		end2();
 
-		for (const path of filtered) {
-			const end4 = logger.start(`> > "${path.relative}" Make ast`);
-
-			const makeAstResult = makeAst(path.absolute, errorsRef);
-			if (makeAstResult === null) {
-				end4();
-				continue;
-			}
-			end4();
-
-			const { ast, positions } = makeAstResult;
-			const rules = calcRules(root, path.absolute, declaration);
-
-			const end5 = logger.start(`> > "${path.relative}" Find import paths`);
-			const infoArray = findImportPaths(ast, positions).map(
-				(v): ReturnType<typeof findImportPaths>[number] => {
-					const relativePath = `./${relative(root, resolve(dirname(path.absolute), v.path.relative))}`;
-					return {
-						path: { relative: relativePath },
-						line: v.line,
-						column: v.column,
-					};
-				},
-			);
-			end5();
-
-			const analyzed = analyzeImportAccess(logger, rules, infoArray);
-
-			reports.push({ path, result: analyzed });
-			scoped.add(path.absolute);
-		}
+		checkScope(logger, declaration, filtered, root, scoped, errorsRef, reports);
 	}
 
+	const ret = { scoped, errorsRef, reports } satisfies Return;
 	end1();
-
-	return {
-		scoped,
-		errorsRef,
-		reports,
-		hasOnlyScopes,
-	};
+	return ret;
 }

--- a/src/exists/index.ts
+++ b/src/exists/index.ts
@@ -1,0 +1,2 @@
+export { assertExists } from "./assert-exists";
+export { exists } from "./exists";

--- a/src/import-config/config.ts
+++ b/src/import-config/config.ts
@@ -3,6 +3,7 @@ import {
 	boolean,
 	function_,
 	minLength,
+	optional,
 	pipe,
 	strictObject,
 	string,
@@ -27,6 +28,7 @@ const rule$ = union([
 const scope$ = strictObject({
 	scope: glob$,
 	rules: array(rule$),
+	only: optional(boolean()),
 });
 
 export const config$ = strictObject({

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,20 @@ export async function main(): Promise<boolean> {
 	const config = await importConfig(logger, configPath);
 	const tsFiles = getAllTsFiles(logger, root);
 
-	const { scoped, errorsRef, reports, hasOnlyScopes } = check(
+	const onlyScopes = config.scopes.filter((scope) => scope.only);
+	const hasOnlyScopes = 0 < onlyScopes.length;
+	const scopeDeclarations = hasOnlyScopes ? onlyScopes : config.scopes;
+
+	if (hasOnlyScopes) {
+		console.info(
+			`Found ${onlyScopes.length} scope(s) with "only: true", processing only these scopes`,
+		);
+		console.info(""); // blank
+	}
+
+	const { scoped, errorsRef, reports } = check(
 		logger,
-		config,
+		scopeDeclarations,
 		tsFiles,
 		root,
 	);
@@ -39,17 +50,17 @@ export async function main(): Promise<boolean> {
 		.flatMap((v) => v.result)
 		.filter((v) => !v.isAllowed).length;
 
-	outputFromTree(
-		buildTree(
-			errorsRef,
-			reports,
-			tsFiles,
-			scoped,
-			needsReportUnscoped,
-			duration,
-			restrictedImports,
-		),
+	const tree = buildTree(
+		errorsRef,
+		reports,
+		tsFiles,
+		scoped,
+		needsReportUnscoped,
+		duration,
+		restrictedImports,
 	);
+
+	outputFromTree(tree);
 
 	if (hasOnlyScopes) {
 		console.info(`Failed due to "only: true" flag`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,12 @@ export async function main(): Promise<boolean> {
 	const config = await importConfig(logger, configPath);
 	const tsFiles = getAllTsFiles(logger, root);
 
-	const { scoped, errorsRef, reports } = check(logger, config, tsFiles, root);
+	const { scoped, errorsRef, reports, hasOnlyScopes } = check(
+		logger,
+		config,
+		tsFiles,
+		root,
+	);
 
 	const duration = end();
 
@@ -45,6 +50,11 @@ export async function main(): Promise<boolean> {
 			restrictedImports,
 		),
 	);
+
+	if (hasOnlyScopes) {
+		console.info(`Failed due to "only: true" flag`);
+		return false;
+	}
 
 	return restrictedImports === 0;
 }


### PR DESCRIPTION
- Added support for a `only: true` flag in the configuration to allow checking only selected scopes.
  - Enhanced logging to indicate when `only: true` scopes are used, including clearer console output.
  - Preserved and improved handling of summary output and program exit logic when `only: true` is used.
- Refactored the scope-checking logic into a dedicated `checkScope` function to improve modularity and maintainability.
- Restructured `check` function to operate directly on scopes, separating the filtering logic into `main.ts`.
- Introduced a new `exists` utility module for checking AST generation results.
- Fixed a broken `npm run build` script by correcting `npm run check -- run` to `npm run check`.