### PR TITLE
Add scope and rule name labeling to improve import rule identification

### DIFF
--- a/src/check/analyze-import-access/analyze.ts
+++ b/src/check/analyze-import-access/analyze.ts
@@ -26,6 +26,6 @@ export function analyze(
 		isAllowed,
 		line: info.line,
 		column: info.column,
-		scopeLabel: matchedRule?.scopeLabel || rulesResult.scope,
+		scopeLabel: matchedRule?.scopeLabel ?? rulesResult.scope,
 	};
 }

--- a/src/check/analyze-import-access/analyze.ts
+++ b/src/check/analyze-import-access/analyze.ts
@@ -1,20 +1,22 @@
 import { minimatch } from "minimatch";
 
-import type { calcRules } from "../calc-rules";
+import type { Rule, calcRules } from "../calc-rules";
 import type { findImportPaths } from "../find-import-paths";
 import type { AnalyzedResult } from "./analyzed-result";
 
 export function analyze(
-	rules: ReturnType<typeof calcRules>,
+	rulesResult: ReturnType<typeof calcRules>,
 	info: ReturnType<typeof findImportPaths>[number],
 ): AnalyzedResult {
 	let isAllowed = false;
+	let matchedRule: Rule | null = null;
 
-	for (const rule of rules) {
+	for (const rule of rulesResult.rules) {
 		const matched = minimatch(info.path.relative, rule.pattern);
 		if (!matched) {
 			continue;
 		}
+		matchedRule = rule;
 		isAllowed = rule.type === "allowed";
 		break;
 	}
@@ -24,5 +26,6 @@ export function analyze(
 		isAllowed,
 		line: info.line,
 		column: info.column,
+		scopeLabel: matchedRule?.scopeLabel || rulesResult.scope,
 	};
 }

--- a/src/check/analyze-import-access/analyzed-result.ts
+++ b/src/check/analyze-import-access/analyzed-result.ts
@@ -7,4 +7,5 @@ export type AnalyzedResult = Readonly<{
 	line: number;
 	column: number;
 	isAllowed: boolean;
+	scopeLabel: string;
 }>;

--- a/src/check/calc-rules.ts
+++ b/src/check/calc-rules.ts
@@ -1,4 +1,6 @@
 import { dirname, relative } from "node:path";
+
+import { assertExists, exists } from "../exists";
 import type { importConfig } from "../import-config";
 
 type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
@@ -6,6 +8,7 @@ type Declaration = Awaited<ReturnType<typeof importConfig>>["scopes"][number];
 export type Rule = Readonly<{
 	type: "allowed" | "restricted";
 	pattern: string;
+	scopeLabel: string;
 }>;
 
 function expandPatterns(patterns: readonly string[]): readonly string[] {
@@ -18,34 +21,55 @@ function expandPatterns(patterns: readonly string[]): readonly string[] {
 	});
 }
 
+function createScopeLabel(
+	scopeName: string,
+	ruleIndex: number,
+	ruleName: string | null,
+): string {
+	return ruleName ? ruleName : `${scopeName}:rule[${ruleIndex}]`;
+}
+
+function getRuleName(
+	rule: NonNullable<Declaration["rules"][number]>,
+): string | null {
+	if (!("name" in rule) || !exists(rule.name)) {
+		return null;
+	}
+	return rule.name.length === 0 ? null : rule.name;
+}
+
 function processSiblingRule(
 	rule: NonNullable<Declaration["rules"][number]>,
 	tsPath: string,
 	root: string,
-):
-	| readonly Readonly<{
-			type: "allowed" | "restricted";
-			pattern: string;
-	  }>[]
-	| null {
+	scopeName: string,
+	ruleIndex: number,
+): readonly Rule[] | null {
 	if (!("sibling" in rule)) {
 		return null;
 	}
 
 	const basePath = `./${relative(root, dirname(tsPath))}`;
 	const patterns = [`${basePath}/**/*`, basePath];
-
 	const ruleType = rule.sibling ? "allowed" : "restricted";
+	const ruleName = getRuleName(rule);
+	const scopeLabel = createScopeLabel(scopeName, ruleIndex, ruleName);
 
 	return patterns.map((pattern) => {
-		return { type: ruleType, pattern };
+		return {
+			type: ruleType,
+			pattern,
+			scopeLabel,
+		};
 	});
 }
 
 function processAllowedRule(
 	rule: NonNullable<Declaration["rules"][number]>,
 	relativePath: string,
-): readonly string[] {
+	scopeName: string,
+	ruleIndex: number,
+): readonly Rule[] {
 	if (!("allowed" in rule)) {
 		return [];
 	}
@@ -62,13 +86,22 @@ function processAllowedRule(
 		);
 	})();
 
-	return expandPatterns(paths);
+	const ruleName = getRuleName(rule);
+	const scopeLabel = createScopeLabel(scopeName, ruleIndex, ruleName);
+
+	return expandPatterns(paths).map((pattern) => ({
+		type: "allowed" as const,
+		pattern,
+		scopeLabel,
+	}));
 }
 
 function processRestrictedRule(
 	rule: NonNullable<Declaration["rules"][number]>,
 	relativePath: string,
-): readonly string[] {
+	scopeName: string,
+	ruleIndex: number,
+): readonly Rule[] {
 	if (!("restricted" in rule)) {
 		return [];
 	}
@@ -85,35 +118,63 @@ function processRestrictedRule(
 		);
 	})();
 
-	return expandPatterns(paths);
+	const ruleName = getRuleName(rule);
+	const scopeLabel = createScopeLabel(scopeName, ruleIndex, ruleName);
+
+	return expandPatterns(paths).map((pattern) => ({
+		type: "restricted" as const,
+		pattern,
+		scopeLabel,
+	}));
 }
+
+type RulesResult = Readonly<{
+	rules: readonly Rule[];
+	scope: string;
+}>;
 
 export function calcRules(
 	root: string,
 	tsPath: string,
 	declaration: Declaration,
-): readonly Rule[] {
+): RulesResult {
 	const relativePath = `./${relative(root, tsPath)}`;
 
 	const orderedRules: /* readwrite */ Rule[] = [];
 
-	for (const rule of declaration.rules) {
-		const siblingRules = processSiblingRule(rule, tsPath, root);
-		if (siblingRules !== null) {
+	for (let i = 0; i < declaration.rules.length; i++) {
+		const rule = declaration.rules[i];
+		assertExists(rule);
+
+		const siblingRules = processSiblingRule(
+			rule,
+			tsPath,
+			root,
+			declaration.scope,
+			i,
+		);
+
+		if (exists(siblingRules)) {
 			orderedRules.push(...siblingRules);
 			continue;
 		}
 
-		const allowedPaths = processAllowedRule(rule, relativePath);
-		for (const pattern of allowedPaths) {
-			orderedRules.push({ type: "allowed", pattern });
-		}
+		const allowedRules = processAllowedRule(
+			rule,
+			relativePath,
+			declaration.scope,
+			i,
+		);
+		orderedRules.push(...allowedRules);
 
-		const restrictedPaths = processRestrictedRule(rule, relativePath);
-		for (const pattern of restrictedPaths) {
-			orderedRules.push({ type: "restricted", pattern });
-		}
+		const restrictedRules = processRestrictedRule(
+			rule,
+			relativePath,
+			declaration.scope,
+			i,
+		);
+		orderedRules.push(...restrictedRules);
 	}
 
-	return orderedRules;
+	return { rules: orderedRules, scope: declaration.scope };
 }

--- a/src/check/check-scope.ts
+++ b/src/check/check-scope.ts
@@ -34,7 +34,10 @@ export function checkScope(
 		const end4 = logger.start(`> > "${path.relative}" Find import paths`);
 		const infoArray = findImportPaths(ast, positions).map(
 			(v): ReturnType<typeof findImportPaths>[number] => {
-				const relativePath = `./${relative(root, resolve(dirname(path.absolute), v.path.relative))}`;
+				const relativePath = `./${relative(
+					root,
+					resolve(dirname(path.absolute), v.path.relative),
+				)}`;
 				return {
 					path: { relative: relativePath },
 					line: v.line,

--- a/src/import-config/config.ts
+++ b/src/import-config/config.ts
@@ -16,12 +16,15 @@ const glob$ = pipe(string(), minLength(1));
 const rule$ = union([
 	strictObject({
 		allowed: union([pipe(array(glob$), minLength(0)), function_()]),
+		name: optional(string()),
 	}),
 	strictObject({
 		restricted: union([pipe(array(glob$), minLength(0)), function_()]),
+		name: optional(string()),
 	}),
 	strictObject({
 		sibling: boolean(),
+		name: optional(string()),
 	}),
 ]);
 

--- a/src/log-tree/build-node-from-results.ts
+++ b/src/log-tree/build-node-from-results.ts
@@ -22,8 +22,17 @@ export function buildNodeFromResults(
 					],
 				},
 				{ type: "text", elements: [{ text: v.path.relative }] },
+				{
+					type: "text",
+					elements: [
+						{
+							text: v.scopeLabel,
+							attributes: [{ type: "color", value: "gray" }],
+						},
+					],
+				},
 			];
 		}),
-		alignment: ["left", "left"],
+		alignment: ["left", "left", "left"],
 	} satisfies TableNode;
 }

--- a/src/testing/case-02/__snapshots__/case-02.test.ts.snap
+++ b/src/testing/case-02/__snapshots__/case-02.test.ts.snap
@@ -37,6 +37,7 @@ exports[`Case 02 > main() > should match the generated log output structure agai
       "alignment": [
         "left",
         "left",
+        "left",
       ],
       "rows": [
         [
@@ -62,6 +63,20 @@ exports[`Case 02 > main() > should match the generated log output structure agai
             ],
             "type": "text",
           },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*",
+              },
+            ],
+            "type": "text",
+          },
         ],
         [
           {
@@ -82,6 +97,20 @@ exports[`Case 02 > main() > should match the generated log output structure agai
             "elements": [
               {
                 "text": "./b/b1",
+              },
+            ],
+            "type": "text",
+          },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*",
               },
             ],
             "type": "text",

--- a/src/testing/case-05/__snapshots__/case-05.test.ts.snap
+++ b/src/testing/case-05/__snapshots__/case-05.test.ts.snap
@@ -37,6 +37,7 @@ exports[`Case 05 > main() > should match the generated log output structure agai
       "alignment": [
         "left",
         "left",
+        "left",
       ],
       "rows": [
         [
@@ -58,6 +59,20 @@ exports[`Case 05 > main() > should match the generated log output structure agai
             "elements": [
               {
                 "text": "./b/b1",
+              },
+            ],
+            "type": "text",
+          },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*:rule[0]",
               },
             ],
             "type": "text",
@@ -86,6 +101,20 @@ exports[`Case 05 > main() > should match the generated log output structure agai
             ],
             "type": "text",
           },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*",
+              },
+            ],
+            "type": "text",
+          },
         ],
         [
           {
@@ -110,6 +139,20 @@ exports[`Case 05 > main() > should match the generated log output structure agai
             ],
             "type": "text",
           },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*",
+              },
+            ],
+            "type": "text",
+          },
         ],
         [
           {
@@ -130,6 +173,20 @@ exports[`Case 05 > main() > should match the generated log output structure agai
             "elements": [
               {
                 "text": "./a/a3",
+              },
+            ],
+            "type": "text",
+          },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*",
               },
             ],
             "type": "text",

--- a/src/testing/case-06/__snapshots__/case-06.test.ts.snap
+++ b/src/testing/case-06/__snapshots__/case-06.test.ts.snap
@@ -37,6 +37,7 @@ exports[`Case 06 > main() > should match the generated log output structure agai
       "alignment": [
         "left",
         "left",
+        "left",
       ],
       "rows": [
         [
@@ -58,6 +59,20 @@ exports[`Case 06 > main() > should match the generated log output structure agai
             "elements": [
               {
                 "text": "./b/b1",
+              },
+            ],
+            "type": "text",
+          },
+          {
+            "elements": [
+              {
+                "attributes": [
+                  {
+                    "type": "color",
+                    "value": "gray",
+                  },
+                ],
+                "text": "./a/**/*:rule[0]",
               },
             ],
             "type": "text",


### PR DESCRIPTION
- Added scope label information to rules to improve visibility of which scope/rule is applied
- Enhanced the `Rule` type with a new `scopeLabel` property for better identification
- Modified the `calcRules` function to return a structured object that includes both rules and scope name
- Added the ability to name rules explicitly through an optional `name` property in rule definitions
- Updated table display in logs to include scope labels with gray coloring
- Refactored the analyze function to track and display which rule matched the import
- Updated test snapshots to reflect the new table structure with scope labels
